### PR TITLE
fix: Add a default value if frame color option is empty

### DIFF
--- a/source/rich-chat.py
+++ b/source/rich-chat.py
@@ -180,7 +180,10 @@ def main():
         help="Any OpenAI compatible server chat endpoint. Like chat.example.com, excluding 'v1/chat' etc.",
     )
     parser.add_argument(
-        "--model-frame-color", type=str, help="Frame color of Large language Model"
+        "--model-frame-color",
+        type=str,
+        default="white",
+        help="Frame color of Large language Model",
     )
     parser.add_argument(
         "--topk",


### PR DESCRIPTION
This fix is really simple.

It sets the default frame color to "white" to prevent a `AttributeError: 'NoneType' object has no attribute 'strip'` from happening on startup.

Users can opt-in to a supported color scheme if the option is given.
