### PR TITLE
Add features and enhancements to user prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.backup
+*.history
+*.log

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Pygments==2.17.2
 requests==2.31.0
 rich==13.7.0
 urllib3==2.2.1
+prompt-toolkit==3.0.43

--- a/source/rich-chat.py
+++ b/source/rich-chat.py
@@ -3,10 +3,14 @@ import json
 import os
 
 import requests
+from prompt_toolkit import PromptSession
 from rich.console import Console
 from rich.live import Live
 from rich.markdown import Markdown
 from rich.panel import Panel
+
+# TODO: Encapsulate the session instance, ideally within the `conchat` class.
+session = PromptSession()
 
 
 def remove_lines_console(num_lines):
@@ -27,18 +31,7 @@ def estimate_lines(text):
 
 
 def handle_console_input() -> str:
-    txt = ""
-    i = 1
-    while True:
-        if i == 1:
-            line = input("Enter prompt(double enter to input): ")
-            i = i + 1
-        else:
-            line = input("")
-        if not line:
-            break
-        txt = txt + line + "\n"
-    return txt.strip()
+    return session.prompt("(Prompt: ⌥ + ⏎) | (Exit: ⌘ + c):\n", multiline=True)
 
 
 class conchat:
@@ -156,15 +149,12 @@ class conchat:
         self.model_name = self.get_model_name()
         while True:
             try:
-
                 user_m = handle_console_input()
                 remove_lines_console(estimate_lines(text=user_m))
                 self.console.print(
                     Panel(Markdown(user_m), title="HUMAN", title_align="left")
                 )
                 self.handle_streaming(prompt=user_m)
-                print()
-                print()
 
             except KeyboardInterrupt:
                 exit()

--- a/source/rich-chat.py
+++ b/source/rich-chat.py
@@ -156,7 +156,9 @@ class conchat:
                 )
                 self.handle_streaming(prompt=user_m)
 
-            except KeyboardInterrupt:
+            # NOTE: Ctrl + c (keyboard) or Ctrl + d (eof) to exit
+            # Adding EOFError prevents an exception and gracefully exits.
+            except (KeyboardInterrupt, EOFError):
                 exit()
 
 

--- a/source/rich-chat.py
+++ b/source/rich-chat.py
@@ -4,13 +4,11 @@ import os
 
 import requests
 from prompt_toolkit import PromptSession
+from prompt_toolkit.history import FileHistory
 from rich.console import Console
 from rich.live import Live
 from rich.markdown import Markdown
 from rich.panel import Panel
-
-# TODO: Encapsulate the session instance, ideally within the `conchat` class.
-session = PromptSession()
 
 
 def remove_lines_console(num_lines):
@@ -30,8 +28,8 @@ def estimate_lines(text):
     return line_count
 
 
-def handle_console_input() -> str:
-    return session.prompt("(Prompt: ⌥ + ⏎) | (Exit: ⌘ + c):\n", multiline=True)
+def handle_console_input(session: PromptSession) -> str:
+    return session.prompt("(Prompt: ⌥ + ⏎) | (Exit: ⌘ + c):\n", multiline=True).strip()
 
 
 class conchat:
@@ -59,6 +57,9 @@ class conchat:
         self.model_name = ""
 
         self.console = Console()
+
+        # TODO: Gracefully handle user input history file.
+        self.session = PromptSession(history=FileHistory(".rich-chat.history"))
 
     def chat_generator(self, prompt):
         endpoint = self.serveraddr + "/v1/chat/completions"
@@ -149,7 +150,7 @@ class conchat:
         self.model_name = self.get_model_name()
         while True:
             try:
-                user_m = handle_console_input()
+                user_m = handle_console_input(self.session)
                 remove_lines_console(estimate_lines(text=user_m))
                 self.console.print(
                     Panel(Markdown(user_m), title="HUMAN", title_align="left")


### PR DESCRIPTION
**Add user prompt history and encapsulate PromptSession within Conchat class**

This pull request introduces the following improvements to the rich-chat CLI application:

1. Add `prompt-toolkit` for enabling enhanced user prompts.
1. Encapsulates the `PromptSession` instance within the `conchat` class for better organization and code reusability.
1. Adds a `FileHistory` instance to maintain user input history across interactions.
1. Passes the session instance as an argument to the `handle_console_input()` function to ensure proper context.
1. Introduces basic keyboard shortcuts for users within the prompt:

  - `(Prompt: ⌥ + ⏎) | (Exit: ⌘ + c):` 
    - Submit a prompt to the model using `alt + enter` or `alt + return`. 
    - Both `ctrl + c` and `ctrl + d` are supported for termination.
  - `⌘ + c`: Submit a KeyboardInterrupt error.
  - `⌘ + d`: Terminate the application (end of file). 
  - `ctrl + a`: Cursor to start of line
  - `ctrl + e`: Cursor to end of line
  - `ctrl + y`: Yank from end of line to start of line
  - `ctrl + l`: Clear the terminal window
  - `ctrl + w`: Yank from end of word to start of word
  - `🞁` and `🞃`: Use up and down navigation keys for navigating prompt and history
  - `🞀` and `🞂`: Use left and right navigation keys for navigating prompt

A cool thing to note is you can use `ctrl + navKey` to jump around the prompt quickly.

Other commands are that are supported by the OS, Distribution, and/or Terminal should also be available. Some are disabled by `prompt-toolkit` and need to be manually enabled.

![Screenshot from 2024-02-19 16-39-03](https://github.com/akarshanbiswas/rich-chat/assets/77757836/48990924-df88-4630-b925-8373b9421f98)

![Screenshot from 2024-02-19 16-40-28](https://github.com/akarshanbiswas/rich-chat/assets/77757836/35aef7a4-ba4f-4146-9813-3304d0623035)

